### PR TITLE
Pin reporting template reference to main

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -175,7 +175,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: telicent-oss/trivy-action
-        ref: self-tests # TODO Set to main once the current PR is finished
+        ref: main
         sparse-checkout: |
           report-template.tpl
         sparse-checkout-cone-mode: false


### PR DESCRIPTION
Since the `self-tests` branch has been merged and deleted can now rely on checking out the report template file from `main`