### PR TITLE
Fix bugs in handling remote-vex input (TELDEVOPS-589)

### DIFF
--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -144,6 +144,43 @@ jobs:
         run: |
           exit 1
 
+  empty-remote-vex:
+    runs-on: ubuntu-latest
+    needs: cache-images
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3.3.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Restore Cached Image
+        uses: telicent-oss/docker-image-cache-action@v1
+        with:
+          images: telicent/telicent-access-api:1.4.2
+          restore-only: true
+        
+      - name: Trivy Image Scan that Fails
+        id: trivy-scan
+        continue-on-error: true
+        uses: telicent-oss/trivy-action@v1
+        with:
+          scan-type: image
+          scan-ref: telicent/telicent-access-api:1.4.2
+          scan-name: empty-remote-vex
+          # Intentionally empty whitespace input for remote-vex
+          remote-vex: |
+               
+      - name: Fail if Trivy didn't fail
+        if: ${{ failure() && steps.trivy-scan.outcome != 'failed' }}
+        run: |
+          exit 1
+
+      - name: Download Scan Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.trivy-scan.outputs.scan-results }}
+
   filesystem-scan:
     runs-on: ubuntu-latest
     steps:

--- a/action.yml
+++ b/action.yml
@@ -179,16 +179,16 @@ runs:
           git remote add -f origin https://github.com/${REPO} || echo "Failed to fetch remote repository ${REPO}"
           git checkout --force ${BRANCH} || echo "Failed to checkout branch ${BRANCH} from remote repository ${REPO}"
           if [ -d ".vex/" ]; then
-            mv -fv .vex/*.json .
+            mv -fv .vex/*.json . || echo "No remote VEX statements found, they MUST have a .json extension and be in the .vex/ directory of the remote repository"
             rm -Rf .vex/
           else
             echo "::warning title=No Remote VEX Statements in ${REPO}::Repository ${REPO} did not contain a .vex/ directory on its ${BRANCH} branch"
           fi
-          git remote remove origin
+          git remote remove origin || echo "No remote origin to remove"
         done
 
         echo "Found the following Remote VEX Statements:"
-        ls -lh *.json
+        ls -lh *.json || echo "No Remote VEX Statements found"
 
         popd
 
@@ -201,11 +201,11 @@ runs:
       run: |
         # If local VEX statements exist merge them together
         if [ -d ".vex/" ]; then
-          vexctl merge .vex/*.json > merged.openvex.json
+          vexctl merge .vex/*.json > merged.openvex.json || rm merged.openvex.json
         fi
         # If any remote VEX statements exist merge them together as well
         if [ -d ".remote-vex/" ]; then
-          vexctl merge .remote-vex/*.json > merged.remote.openvex.json
+          vexctl merge .remote-vex/*.json > merged.remote.openvex.json || rm merged.remote.openvex.json
         fi
 
         # If both local and remote VEX statements exist merge them together into a final


### PR DESCRIPTION
In some cases the `remote-vex` input handling code path could be triggered, even though no repository references are actually provided.  Or in cases where they were provided and no remote VEX statements were present the merging code did not handle this case correctly.

As a result of this some of the bash commands would then fail which would incorrectly fail the entire action rather than continuing onwards with no remote VEX statements.

Includes new self-test that verifies that this bug, as observed in our workflows, is fixed.

# Related Issues and PRs

- After merging telicent-oss/shared-workflows#112 realised that instead of now allowing builds to pass it was causing all builds to fail because of these errors, e.g. https://github.com/telicent-oss/smart-caches-core/actions/runs/14243856376/job/40087376144, with this fix the build passes again, e.g. https://github.com/telicent-oss/smart-cache-graph/actions/runs/14271437069/job/40088351393