### PR TITLE
Fix auth to remote repositories for Remote VEX statements (TELDEVOPS-589)

### DIFF
--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Trivy Image Scan that Passes
         id: trivy-scan
-        uses: telicent-oss/trivy-action@TELDEVOPS-589
+        uses: telicent-oss/trivy-action@v1
         with:
           scan-type: image
           scan-ref: telicent/telicent-java21:1.2.6

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Trivy Image Scan that Passes
         id: trivy-scan
-        uses: telicent-oss/trivy-action@v1
+        uses: telicent-oss/trivy-action@TELDEVOPS-589
         with:
           scan-type: image
           scan-ref: telicent/telicent-java21:1.2.6
@@ -114,6 +114,8 @@ jobs:
             telicent-oss/trivy-action
               telicent-oss/no-such-repo    
             telicent-oss/telicent-base-images
+          gh-user: rvesse
+          gh-token: ${{ secrets.TEST_TOKEN }}
 
   failing-image-scan:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ jobs:
   example:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
 
     steps:
@@ -47,6 +46,32 @@ jobs:
 
 In the above example we invoke the action twice, once to do a `fs` scan and another to do an `image` scan.
 
+## GitHub Token Permissions
+
+This action needs a GitHub Token in order to query the GitHub Releases API to discover the release binaries for
+installing the necessary `trivy` and `vexctl` tools.  By default we take the default GitHub Token for the workflow from
+the `github.token` context.  If you have restricted the `permissions` in your Workflow file then you **MAY** need to provide a custom token rather than relying on the default.
+
+If your build fails with the following error:
+
+> You need at least read:packages scope to get a package's versions.
+
+Then your token does not have correct permissions, either amend the `permissions` you are requesting for the token in
+your workflow configuration, or use an Actions secret to provide a token for this purpose.
+
+### Permissions for Remote VEX
+
+Also, if you are using the [Remote VEX](#remote-vex-statements) feature then you **MUST** provide a token that has
+permissions to read all the repositories you want to retrieve Remote VEX statements from otherwise some repositories
+**MAY** be ignored, and you **MAY** not get the desired vulnerability suppressions you are expecting.
+
+In this scenario the minimum permissions required for this feature to work correctly are `read:packages` and `repo`, and
+for the `repo` permission it **MUST** pertain to all repositories you wish to access.  This means that the default
+GitHub token permissions are generally **NOT** sufficient to use this feature.
+
+If you provide a custom GitHub token then you **MUST** also customise the `gh-user` input to match the username of the
+user who generated the GitHub token.
+
 ## VEX Support
 
 This action now includes built-in support for processing of Vulnerability Exploitability Exchange (VEX) statements in
@@ -64,6 +89,10 @@ Any vulnerabilities that are suppressed as a result will be displayed in the Git
 Trivy JSON Report:
 
 ![Example Suppressed Vulnerabilities Report](vex-suppression-example.png)
+
+**NB** If you are setting the `allow-unfixed` input to `true` then if a vulnerability is unfixed and has VEX statements
+about it Trivy always ignores it.  Therefore we recommend **NOT** setting `allow-unfixed` unless you absolutely must do
+so.
 
 ### Remote VEX Statements
 
@@ -85,7 +114,6 @@ jobs:
   example:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
 
     steps:
@@ -102,15 +130,25 @@ jobs:
           remote-vex: |
             telicent-oss/telicent-base-images
             telicent-oss/smart-caches-core
+          gh-user: ${{ secrets.REMOTE_VEX_USER }}
+          gh-token: ${{ secrets.REMOTE_VEX_TOKEN }}
 ```
 
 Here we are configuring the action to retrieve remote VEX statements from the `telicent-oss/telicent-base-images` and
 `telicent-oss/smart-caches-core` repositories `main` branches.
 
+Notice that for this to work we need to set the `gh-user` and `gh-token` inputs to custom values, in this example these
+reference some Action secrets that have been created.  The token passed in as the `gh-token` input **MUST** have the
+ability to read the contents of this repository, it **MUST** also have the ability to read packages from repositories as
+the `trivy` and `vexctl` command line tools needed are installed via querying the GitHub Releases API, see [Token Permissions](#github-token-permissions) for more information on this.
+
 Note that if any of the specified repositories does not exist, does not have the referenced branch, or no `.vex/`
 directory exists on that branch then a build warning is issued e.g.
 
 ![No Remote VEX Warning example](no-remote-vex-warning.png)
+
+This warning is issued regardless of the reason for failure e.g. bad [Token Permissions](#github-token-permissions), no
+`.vex/` directory in remote repository etc.
 
 # Inputs
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ In the above example we invoke the action twice, once to do a `fs` scan and anot
 
 This action needs a GitHub Token in order to query the GitHub Releases API to discover the release binaries for
 installing the necessary `trivy` and `vexctl` tools.  By default we take the default GitHub Token for the workflow from
-the `github.token` context.  If you have restricted the `permissions` in your Workflow file then you **MAY** need to provide a custom token rather than relying on the default.
+the `github.token` context.  If you have restricted the `permissions` in your Workflow file then you **MAY** need to
+provide a custom token rather than relying on the default.
 
 If your build fails with the following error:
 
@@ -140,7 +141,8 @@ Here we are configuring the action to retrieve remote VEX statements from the `t
 Notice that for this to work we need to set the `gh-user` and `gh-token` inputs to custom values, in this example these
 reference some Action secrets that have been created.  The token passed in as the `gh-token` input **MUST** have the
 ability to read the contents of this repository, it **MUST** also have the ability to read packages from repositories as
-the `trivy` and `vexctl` command line tools needed are installed via querying the GitHub Releases API, see [Token Permissions](#github-token-permissions) for more information on this.
+the `trivy` and `vexctl` command line tools needed are installed via querying the GitHub Releases API, see [Token
+Permissions](#github-token-permissions) for more information on this.
 
 Note that if any of the specified repositories does not exist, does not have the referenced branch, or no `.vex/`
 directory exists on that branch then a build warning is issued e.g.

--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,17 @@ inputs:
     default: ${{ github.token }}
     description: |
       A GitHub Token needed to determine the current Trivy database version for caching.
-      Defaults to github.token which is the token for this build, can be overridden if this default token doesn't work
+      Defaults to `github.token` which is the token for this build, can be overridden if this default token doesn't work
       for your build environment.
+  gh-user:
+    required: false
+    default: ${{ github.actor }}
+    description: |
+      A GitHub User to use when cloning remote repositories to retrieve remote VEX statements.
+
+      Defaults to `github.actor` which is the user running the build, can be overridden if this default user does not 
+      match the user who owns the `gh-token` input e.g. if providing a custom GitHub Token to retrieve VEX statements
+      from private repositories.
   uses-java:
     required: false
     default: "false"
@@ -173,10 +182,10 @@ runs:
           fi
 
           # Actually retrieve remote VEX statements
-          # Note the exit 0 to force us to continue even if we get a bad repository reference/branch
-          # In this case we'll hit the else branch and issue a Warning
+          # If a remote reference can't be retrieved then we simply log that
+          # If a remote reference is valid but contains no remote VEX statements then we issue a warning
           echo "Retrieving Remote VEX statements from ${BRANCH} branch of ${REPO}"
-          git remote add -f origin https://github.com/${REPO} || echo "Failed to fetch remote repository ${REPO}"
+          git remote add -f origin https://${{ inputs.gh-user }}:${{ inputs.gh-token }}@github.com/${REPO} || echo "Failed to fetch remote repository ${REPO}"
           git checkout --force ${BRANCH} || echo "Failed to checkout branch ${BRANCH} from remote repository ${REPO}"
           if [ -d ".vex/" ]; then
             mv -fv .vex/*.json . || echo "No remote VEX statements found, they MUST have a .json extension and be in the .vex/ directory of the remote repository"


### PR DESCRIPTION
Discovered as we rolled the `remote-vex` feature out that authentication to remote repositories wasn't reliably functioning.  This commit aims to address that, note that it potentially requires callers to supply a custom GitHub User and Token.