### PR TITLE
Fix bad remote VEX merge failing builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -160,7 +160,7 @@ runs:
     - name: Download Remote VEX Statements
       if: ${{ inputs.remote-vex != '' }}
       shell: bash
-      run: |
+      run: |    
         mkdir .remote-vex
         pushd .remote-vex
         git init -b main
@@ -196,10 +196,12 @@ runs:
           git remote remove origin || echo "No remote origin to remove"
         done
 
-        echo "Found the following Remote VEX Statements:"
-        ls -lh *.json || echo "No Remote VEX Statements found"
-
         popd
+
+        # List the Remote VEX statements found, if none found remove the .remote-vex/ directory otherwise the prepare-vex steps fails
+        echo "Found the following Remote VEX Statements:"
+        ls -lh .remote-vex/*.json || echo "No Remote VEX Statements found" && rm -Rf .remote-vex/
+
 
     # For convenience as there may be many VEX statements present merge them into a single VEX file that we then
     # pass into Trivy by setting the TRIVY_VEX environment variable


### PR DESCRIPTION
As seen in various builds, e.g. https://github.com/telicent-oss/graphql-jena/actions/runs/15124332523/job/42538727837?pr=74, the changes in PR #9 meant that when the `.remote-vex` directory ends up empty it fails the merge action in the merge step which then erroneously fails the entire build.  To fix this we now delete the `.remote-vex/` directory if it ends up containing no VEX statements so we then won't try to merge it and fail builds