### PR TITLE
Update CVE-2025-4638.openvex.json

### DIFF
--- a/.vex/CVE-2025-4638.openvex.json
+++ b/.vex/CVE-2025-4638.openvex.json
@@ -12,10 +12,10 @@
       "timestamp": "2025-05-19T10:45:18.549079+01:00",
       "products": [
         {
-          "@id": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=aarch64&distro=redhat-9.6"
+          "@id": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=aarch64\u0026distro=redhat-9.6"
         },
         {
-          "@id": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64&distro=redhat-9.6"
+          "@id": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64\u0026distro=redhat-9.6"
         }
       ],
       "status": "not_affected",


### PR DESCRIPTION
Package IDs MUST match exactly what is in the Trivy Report JSON i.e.

```json
{
          "VulnerabilityID": "CVE-2025-4638",
          "PkgID": "zlib@1.2.11-40.el9.x86_64",
          "PkgName": "zlib",
          "PkgIdentifier": {
            "PURL": "pkg:rpm/redhat/zlib@1.2.11-40.el9?arch=x86_64\u0026distro=redhat-9.6",
            "UID": "ac3e44507ded7338"
          },
```