### PR TITLE
Pin Trivy actions to SHA hashes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -134,9 +134,9 @@ runs:
         echo "name=$(echo '${{ inputs.scan-name }}' | sed 's/[:/<>|*?\]/-/g' | tr -s '-')" >> $GITHUB_OUTPUT
 
     - name: Setup Trivy
-      uses: aquasecurity/setup-trivy@v0.2.6
+      uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514
       with:
-        version: v0.69.2
+        version: v0.69.3
         cache: true
 
     - name: Trivy Cache
@@ -148,7 +148,7 @@ runs:
 
     - name: Download Trivy Java DB
       if: ${{ inputs.uses-java == 'true' && (steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false') }}
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       env:
         TRIVY_DOWNLOAD_JAVA_DB_ONLY: true
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db:1
@@ -164,7 +164,7 @@ runs:
 
     - name: Download Trivy Vulnerability DB
       if: ${{ steps.trivy-cache.outputs.cache-hit == '' || steps.trivy-cache.outputs.cache-hit == 'false' }}
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       env:
         TRIVY_DOWNLOAD_DB_ONLY: true
         TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db:2
@@ -187,7 +187,7 @@ runs:
 
     # Perform a full vulnerability to generate a full vulnerability report
     - name: Trivy Vulnerability Scan
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       env:
         TRIVY_SKIP_DB_UPDATE: true
         TRIVY_SKIP_JAVA_DB_UPDATE: true
@@ -223,7 +223,7 @@ runs:
     - name: Generate SBOM if Requested
       id: generate-sbom
       if: ${{ inputs.output-sbom != '' }}
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       env:
         TRIVY_SKIP_DB_UPDATE: true
         TRIVY_SKIP_JAVA_DB_UPDATE: true
@@ -275,7 +275,7 @@ runs:
 
     - name: Fail build on High/Criticial Vulnerabilities
       id: gating-scan
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
       env:
         TRIVY_SKIP_DB_UPDATE: true
         TRIVY_SKIP_JAVA_DB_UPDATE: true


### PR DESCRIPTION
This avoids the possibility of a supply chain attack against the Trivy actions that could result in us pulling a compromised version of the Action if we didn't do this