### PR TITLE
Use Alpine 3.23.4 for self-tests

### DIFF
--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [ "telicent/telicent-java21:1.2.40", "telicent/telicent-access-api:1.4.2", "alpine:3.23.3" ]
+        image: [ "telicent/telicent-java21:1.2.40", "telicent/telicent-access-api:1.4.2", "alpine:3.23.4" ]
       fail-fast: true
     steps:
       - name: Cache Images
@@ -30,7 +30,7 @@ jobs:
     needs: cache-images
     strategy:
       matrix:
-        image: [ "telicent/telicent-java21:1.2.40", "alpine:3.23.3" ]
+        image: [ "telicent/telicent-java21:1.2.40", "alpine:3.23.4" ]
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
This resolves failing self-tests due to vulnerable packages in the older `3.23.3` image